### PR TITLE
Add API endpoint to solve TSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,21 @@ Desarrollar una solución modular con componentes de **backend** y **frontend** 
    # instala dependencias del frontend (por ejemplo, con npm)
    ```
 
+## Ejecución del servidor backend
+
+1. Crea un entorno virtual en la carpeta `backend` y activa el entorno:
+   ```bash
+   cd backend
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Instala las dependencias necesarias:
+   ```bash
+   pip install flask ortools
+   ```
+3. Inicia el servidor:
+   ```bash
+   python app.py
+   ```
+
+La API expone la ruta `/api/solve`, la cual recibe un JSON con un arreglo `coordinates` y devuelve la secuencia óptima calculada.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,58 @@
+from flask import Flask, request, jsonify
+from ortools.constraint_solver import pywrapcp, routing_enums_pb2
+import math
+
+app = Flask(__name__)
+
+
+def create_distance_matrix(coords):
+    size = len(coords)
+    matrix = [[0] * size for _ in range(size)]
+    for i in range(size):
+        for j in range(size):
+            if i == j:
+                continue
+            x1, y1 = coords[i]
+            x2, y2 = coords[j]
+            matrix[i][j] = int(math.hypot(x2 - x1, y2 - y1) * 1000)
+    return matrix
+
+
+@app.route('/api/solve', methods=['POST'])
+def solve_tsp():
+    data = request.get_json()
+    coords = data.get('coordinates') if data else None
+    if not coords:
+        return jsonify({'error': 'No coordinates provided'}), 400
+
+    distance_matrix = create_distance_matrix(coords)
+    manager = pywrapcp.RoutingIndexManager(len(distance_matrix), 1, 0)
+    routing = pywrapcp.RoutingModel(manager)
+
+    def distance_callback(from_index, to_index):
+        from_node = manager.IndexToNode(from_index)
+        to_node = manager.IndexToNode(to_index)
+        return distance_matrix[from_node][to_node]
+
+    transit_callback_index = routing.RegisterTransitCallback(distance_callback)
+    routing.SetArcCostEvaluatorOfAllVehicles(transit_callback_index)
+
+    search_params = pywrapcp.DefaultRoutingSearchParameters()
+    search_params.first_solution_strategy = routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
+
+    solution = routing.SolveWithParameters(search_params)
+    if not solution:
+        return jsonify({'error': 'No solution found'}), 500
+
+    index = routing.Start(0)
+    route = []
+    while not routing.IsEnd(index):
+        route.append(manager.IndexToNode(index))
+        index = solution.Value(routing.NextVar(index))
+    route.append(manager.IndexToNode(index))
+
+    return jsonify({'route': route})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add Flask backend with `/api/solve` that uses OR-Tools for TSP
- update README with steps to run backend in a virtual environment

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68507da8cb28832fbebe73f3595ec0de