### PR TITLE
Add simple frontend with canvas

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TSP Frontend</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <canvas id="canvas" width="500" height="400"></canvas>
+        <div class="controls">
+            <button id="addBtn">Agregar</button>
+            <button id="clearBtn">Eliminar</button>
+        </div>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,27 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const points = [];
+
+canvas.addEventListener('click', event => {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    points.push({ x, y });
+    drawPoint(x, y);
+});
+
+function drawPoint(x, y) {
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(x, y, 3, 0, Math.PI * 2);
+    ctx.fill();
+}
+
+document.getElementById('clearBtn').addEventListener('click', () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    points.length = 0;
+});
+
+document.getElementById('addBtn').addEventListener('click', () => {
+    console.log('Puntos actuales:', points);
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,25 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+.container {
+    max-width: 520px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+#canvas {
+    border: 1px solid #ccc;
+    background-color: #fafafa;
+    cursor: crosshair;
+}
+
+.controls {
+    margin-top: 10px;
+}
+
+button {
+    margin: 0 5px;
+    padding: 5px 10px;
+}


### PR DESCRIPTION
## Summary
- add minimal interface in `frontend/index.html`
- style the page for clarity
- handle canvas clicks and point storage in `main.js`

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68507eedf43c832f98aa790b4879cc79