### PR TITLE
Add backend validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,15 @@ La API expone la ruta `/api/solve`, la cual recibe un JSON con un arreglo `coord
 2. Haz clic en el canvas para agregar ciudades.
 3. Pulsa **Agregar** para enviar las coordenadas al backend.
 4. Se dibujarán líneas entre las ciudades siguiendo el orden óptimo devuelto por la API.
+
+## Ejecutar pruebas
+
+Para verificar el funcionamiento del solver se incluye una suite de pruebas basada en `unittest` dentro del directorio `backend/tests`.
+Con un entorno virtual activo, ejecuta:
+
+```bash
+cd backend
+python -m unittest discover -s tests
+```
+
+Esto correrá pruebas sencillas sobre el endpoint `/api/solve`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -22,8 +22,16 @@ def create_distance_matrix(coords):
 def solve_tsp():
     data = request.get_json()
     coords = data.get('coordinates') if data else None
-    if not coords:
+    if not coords or not isinstance(coords, list):
         return jsonify({'error': 'No coordinates provided'}), 400
+    if len(coords) < 2:
+        return jsonify({'error': 'At least two coordinates required'}), 400
+    if any(
+        not isinstance(c, (list, tuple)) or len(c) != 2 or
+        not all(isinstance(v, (int, float)) for v in c)
+        for c in coords
+    ):
+        return jsonify({'error': 'Invalid coordinates format'}), 400
 
     distance_matrix = create_distance_matrix(coords)
     manager = pywrapcp.RoutingIndexManager(len(distance_matrix), 1, 0)

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,0 +1,30 @@
+import unittest
+from backend.app import app
+
+
+class SolverTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
+    def test_solve_small_example(self):
+        coords = [[0, 0], [0, 1], [1, 0]]
+        response = self.client.post('/api/solve', json={'coordinates': coords})
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        route = data.get('route')
+        self.assertEqual(len(route), len(coords) + 1)
+        self.assertEqual(route[0], 0)
+        self.assertEqual(route[-1], 0)
+        self.assertEqual(set(route[:-1]), set(range(len(coords))))
+
+    def test_invalid_coordinates(self):
+        response = self.client.post('/api/solve', json={'coordinates': [[1, 2, 3]]})
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_coordinates(self):
+        response = self.client.post('/api/solve', json={})
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate input to `/api/solve`
- add unit tests for the solver
- document how to run tests

## Testing
- `python -m unittest discover -s backend/tests -v`

------
https://chatgpt.com/codex/tasks/task_e_685080200188832f9478187663983dc7