### PR TITLE
Improve TSP demo usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Desarrollar una solución modular con componentes de **backend** y **frontend** 
    ```
 2. Instala las dependencias necesarias:
    ```bash
-   pip install flask ortools
+   pip install flask flask-cors ortools
    ```
 3. Inicia el servidor:
    ```bash
@@ -49,9 +49,9 @@ La API expone la ruta `/api/solve`, la cual recibe un JSON con un arreglo `coord
 ## Probar la aplicación
 
 1. Con el backend en funcionamiento, abre la página del frontend.
-2. Haz clic en el canvas para agregar ciudades.
-3. Pulsa **Agregar** para enviar las coordenadas al backend.
-4. Se dibujarán líneas entre las ciudades siguiendo el orden óptimo devuelto por la API.
+2. Haz clic en el canvas para agregar ciudades. Verás la lista de coordenadas debajo del lienzo.
+3. Pulsa **Mejor Ruta** para enviar las coordenadas al backend.
+4. Se dibujará la ruta óptima en el canvas siguiendo el orden devuelto por la API.
 
 ## Ejecutar pruebas
 
@@ -59,8 +59,7 @@ Para verificar el funcionamiento del solver se incluye una suite de pruebas basa
 Con un entorno virtual activo, ejecuta:
 
 ```bash
-cd backend
-python -m unittest discover -s tests
+python -m unittest discover -s backend/tests
 ```
 
 Esto correrá pruebas sencillas sobre el endpoint `/api/solve`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,10 @@
 from flask import Flask, request, jsonify
+from flask_cors import CORS
 from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 import math
 
 app = Flask(__name__)
+CORS(app)
 
 
 def create_distance_matrix(coords):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,8 +9,9 @@
 <body>
     <div class="container">
         <canvas id="canvas" width="500" height="400"></canvas>
+        <ul id="pointsList" class="points"></ul>
         <div class="controls">
-            <button id="addBtn">Agregar</button>
+            <button id="solveBtn">Mejor Ruta</button>
             <button id="clearBtn">Eliminar</button>
         </div>
     </div>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,6 +1,7 @@
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const points = [];
+const list = document.getElementById('pointsList');
 
 canvas.addEventListener('click', event => {
     const rect = canvas.getBoundingClientRect();
@@ -8,6 +9,7 @@ canvas.addEventListener('click', event => {
     const y = event.clientY - rect.top;
     points.push({ x, y });
     drawPoint(x, y);
+    updateList();
 });
 
 function drawPoint(x, y) {
@@ -20,9 +22,10 @@ function drawPoint(x, y) {
 document.getElementById('clearBtn').addEventListener('click', () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     points.length = 0;
+    updateList();
 });
 
-document.getElementById('addBtn').addEventListener('click', async () => {
+document.getElementById('solveBtn').addEventListener('click', async () => {
     if (points.length < 2) {
         alert('Debes agregar al menos dos puntos');
         return;
@@ -30,7 +33,7 @@ document.getElementById('addBtn').addEventListener('click', async () => {
 
     const coordinates = points.map(p => [p.x, p.y]);
     try {
-        const response = await fetch('/api/solve', {
+        const response = await fetch('http://localhost:5000/api/solve', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ coordinates })
@@ -58,4 +61,13 @@ function drawRoute(route) {
         ctx.lineTo(p.x, p.y);
     }
     ctx.stroke();
+}
+
+function updateList() {
+    list.innerHTML = '';
+    points.forEach((p, idx) => {
+        const li = document.createElement('li');
+        li.textContent = `${idx + 1}: (${p.x.toFixed(1)}, ${p.y.toFixed(1)})`;
+        list.appendChild(li);
+    });
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -15,6 +15,15 @@ body {
     cursor: crosshair;
 }
 
+.points {
+    list-style: none;
+    padding: 0;
+    margin-top: 10px;
+    text-align: left;
+    max-height: 100px;
+    overflow-y: auto;
+}
+
 .controls {
     margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- allow CORS on the backend so the frontend can reach the API
- list points as they are added to confirm they're stored
- add a "Mejor Ruta" button to calculate the optimal path
- update JS to call the backend on port 5000 and draw the route
- adjust styles and README instructions

## Testing
- `python -m unittest discover -s backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68507cbe4790832fa5ba1b29c6e4b7ea